### PR TITLE
Improve GitHub workflows

### DIFF
--- a/.github/workflows/gradle-build-with-detekt.yml
+++ b/.github/workflows/gradle-build-with-detekt.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3.0.0
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: liberica
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.0.4
-      - uses: gradle/gradle-build-action@v2.1.5
+      - uses: gradle/gradle-build-action@v2
         with:
           arguments: build --stacktrace -PrunDetekt
           

--- a/.github/workflows/gradle-build-with-detekt.yml
+++ b/.github/workflows/gradle-build-with-detekt.yml
@@ -2,6 +2,12 @@ name: Gradle Build With Detekt
 
 on: [push, pull_request]
 
+# Allow cancelling all previous runs for the same branch
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -2,6 +2,12 @@ name: Gradle Build
 
 on: [push, pull_request]
 
+# Allow cancelling all previous runs for the same branch
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3.0.0
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: liberica
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.0.4
-      - uses: gradle/gradle-build-action@v2.1.5
+      - uses: gradle/gradle-build-action@v2
         with:
           arguments: build --stacktrace
           


### PR DESCRIPTION
- Update versions of some github actions to fix warning of deprecated API usages
- Cancel outdated runs of the same workflow. It's useful not to finish workflow and free runners after pushing new changes into the same branch. In most cases, you don't need previous results

| Warnings before | Warnings after |
| - | - |
| <img width="576" alt="Screenshot 2023-11-17 at 17 53 56" src="https://github.com/jetbrains-academy/kotlin-course-template/assets/2539310/93f1af37-423a-42ef-816c-b6aab7af11ab"> | <img width="402" alt="Screenshot 2023-11-17 at 17 54 09" src="https://github.com/jetbrains-academy/kotlin-course-template/assets/2539310/d9352d3c-c88c-4329-9b48-ac8277b5a6f4"> |

